### PR TITLE
👷chore: Add port setting items to .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,9 @@
 
 http_proxy=http://host.docker.internal:3128
 https_proxy=http://host.docker.internal:3128
+
+# Ports to be bound to HAProxy
+# for requests to the application
+APP_PORT=8080
+# for showing haproxy stats
+STATS_PORT=8081

--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ https_proxy=http://host.docker.internal:3128
 APP_PORT=8080
 # for showing haproxy stats
 STATS_PORT=8081
+
+# Port to be bound to Cassandra
+CASSANDRA_PORT=9042

--- a/bin/demo-request.sh
+++ b/bin/demo-request.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+readonly base_dir="$(cd "$(dirname "$0")"; pwd)"
+readonly env_file="${base_dir}/../.env"
 readonly account_no="$1"
 
 readonly ANSI_COLOR_RED='\e[31m'
@@ -10,6 +12,12 @@ if [[ -z "${account_no}" ]]
 then
   echo 'account_no must be set' >&2
   exit 1
+fi
+
+if [[ -f "${env_file}" ]]
+then
+  # loads env file for docker-compose
+  source "${env_file}"
 fi
 
 function timestamp {
@@ -34,5 +42,5 @@ function decorate_stdout {
 
 while sleep 0.1
 do
-  curl --max-time 1 -sS -X POST "localhost:8080/accounts/${account_no}/deposit?amount=100" 1> >(decorate_stdin) 2> >(decorate_stdout)
+  curl --noproxy localhost --max-time 1 -sS -X POST "localhost:${APP_PORT:-8080}/accounts/${account_no}/deposit?amount=100" 1> >(decorate_stdin) 2> >(decorate_stdout)
 done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,5 +71,5 @@ services:
     volumes:
       - ./docker/haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg
     ports:
-      - 127.0.0.1:8080:8080
-      - 127.0.0.1:8081:8081
+      - 127.0.0.1:${APP_PORT:-8080}:8080
+      - 127.0.0.1:${STATS_PORT:-8081}:8081

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   cassandra:
     image: cassandra:latest
     ports:
-    - 127.0.0.1:9042:9042
+    - 127.0.0.1:${CASSANDRA_PORT:-9042}:9042
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "cqlsh -e 'SELECT now() FROM system.local;'"]


### PR DESCRIPTION
fix: #6

## verification

- ✅ `APP_PORT` and `STATS_PORT` settings change HAProxy container ports
- ✅ HAProxy container binds 8080 and 8081 if `.env` does not exist
- ✅ `demo-requet.sh` requests to `APP_PORT` if `.env` exists
- ✅ `demo-requet.sh` requests to 8080 if `.env` does not exist