### PR TITLE
Release 2021.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ To stop the cassandra container and remove all data, run the following command.
 docker-compose down --volumes
 ```
 
+
+## Versioning Strategy
+We use the [Calendar Versioning](https://calver.org/) `YYYY.MM.MICRO`. 
+
 ## License
 
 akka-entity-replication-sample is released under the terms of the [Apache License Version 2.0](LICENSE).

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 
 ThisBuild / scalaVersion := "2.13.4"
-ThisBuild / version := "1.0.0"
+ThisBuild / version := "2021.7.0"
 ThisBuild / organization := "com.example"
 ThisBuild / organizationName := "example"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       retries: 5
 
   node1:
-    image: sample-akka-entity-replication:1.0.0
+    image: sample-akka-entity-replication:2021.7.0
     restart: always
     depends_on:
       cassandra:
@@ -34,7 +34,7 @@ services:
         -Dakka-entity-replication.eventsourced.persistence.cassandra.journal.tables-autocreate=true
 
   node2:
-    image: sample-akka-entity-replication:1.0.0
+    image: sample-akka-entity-replication:2021.7.0
     restart: always
     depends_on:
       cassandra:
@@ -48,7 +48,7 @@ services:
         -Ddatastax-java-driver.basic.contact-points.0=cassandra:9042
 
   node3:
-    image: sample-akka-entity-replication:1.0.0
+    image: sample-akka-entity-replication:2021.7.0
     restart: always
     depends_on:
       cassandra:


### PR DESCRIPTION
Release 2021.7.0

## Note
We change the versioning strategy to [Calendar Versioning — CalVer](https://calver.org/) which seems to be more suitable for an example project.

## Test

I've confirmed a built image is tagged `2021.7.0`.
```
$ sbt --batch docker:publishLocal
(...truncated)
[info] Built image sample-akka-entity-replication with tags [2021.7.0]
[success] Total time: 15 s, completed 2021/07/16 15:11:53
```

I've also confirmed the application works well.
```
$ bin/demo-request.sh 100
15:16:29.094 [OK] DepositSucceeded(1600)
15:16:29.647 [OK] DepositSucceeded(1700)
15:16:30.182 [OK] DepositSucceeded(1800)
15:16:30.708 [OK] DepositSucceeded(1900)
15:16:31.285 [OK] DepositSucceeded(2000)
15:16:31.849 [OK] DepositSucceeded(2100)
```

## TODO (after merged)
- [ ] make tag `v2021.7.0`